### PR TITLE
add Slice

### DIFF
--- a/AtCoderLibrary/FenwickTree.cs
+++ b/AtCoderLibrary/FenwickTree.cs
@@ -99,6 +99,8 @@ namespace AtCoder
         private static readonly TOp op = default;
         private readonly TValue[] data;
 
+        public int Length { get; }
+
         /// <summary>
         /// 長さ <paramref name="n"/> の配列aを持つ <see cref="FenwickTree{TValue, TOp}"/> クラスの新しいインスタンスを作ります。
         /// </summary>
@@ -110,6 +112,7 @@ namespace AtCoder
         public FenwickTree(int n)
         {
             Debug.Assert(unchecked((uint)n <= 100_000_000));
+            Length = n;
             data = new TValue[n + 1];
         }
 
@@ -156,6 +159,8 @@ namespace AtCoder
             return s;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TValue Slice(int l, int len) => Sum(l, l + len);
 
         [DebuggerDisplay("Value = {" + nameof(value) + "}, Sum = {" + nameof(sum) + "}")]
         private struct DebugItem

--- a/AtCoderLibrary/LazySegtree.cs
+++ b/AtCoderLibrary/LazySegtree.cs
@@ -152,6 +152,9 @@ namespace AtCoder
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TValue Slice(int l, int len) => Prod(l, l + len);
+
         /// <summary>
         /// <see cref="TOp.Operate"/>(a[<paramref name="l"/>], ..., a[<paramref name="r"/> - 1]) を返します。<paramref name="l"/> = <paramref name="r"/> のときは　<see cref="TOp.Identity"/> を返します。
         /// </summary>

--- a/AtCoderLibrary/Segtree.cs
+++ b/AtCoderLibrary/Segtree.cs
@@ -115,6 +115,8 @@ namespace AtCoder
                 return d[p + size];
             }
         }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TValue Slice(int l, int len) => Prod(l, l + len);
 
         /// <summary>
         /// <see cref="TOp.Operate"/>(a[<paramref name="l"/>], ..., a[<paramref name="r"/> - 1]) を返します。<paramref name="l"/> = <paramref name="r"/> のときは　<see cref="TOp.Identity"/> を返します。


### PR DESCRIPTION
FenwickTree, Segtree, LazySegtree の範囲演算をインデクサで取得できるようにした。
ただし、`Range` を引数に取ると遅くなるため、`Slice` と `Length` で展開される方式を採用する。
close #9 


## Benchmarks

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.401
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT


|  Method |       Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |-----------:|---------:|---------:|------:|------:|------:|----------:|
| TwoArgs |   855.5 ms |  6.18 ms |  4.82 ms |     - |     - |     - | 381.47 MB |
|   Range | 1,480.0 ms | 14.16 ms | 12.56 ms |     - |     - |     - | 381.47 MB |
|   Slice |   863.1 ms |  2.45 ms |  2.29 ms |     - |     - |     - | 381.47 MB |

<details><summary>Code</summary>

```C#
using System;
using System.Diagnostics;
using System.Linq;
using System.Linq.Expressions;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;

class Program
{
    static void Main()
    {
        BenchmarkRunner.Run<AclBench>(DefaultConfig.Instance.AddDiagnoser(MemoryDiagnoser.Default));
    }
}

public class AclBench
{
    const int N = 50_000_000;

    [Benchmark]
    public long TwoArgs()
    {
        long sum = 0;
        var ft = new FenwickTree(N);
        for (int i = 0; i < N; i++)
            sum += ft.Sum(0, i);
        return sum;
    }

    [Benchmark]
    public long Range()
    {
        long sum = 0;
        var ft = new FenwickTree(N);
        for (int i = 0; i < N; i++)
            sum += ft.Sum(0..i);
        return sum;
    }

    [Benchmark]
    public long Slice()
    {
        long sum = 0;
        var ft = new FenwickTree(N);
        for (int i = 0; i < N; i++)
            sum += ft[0..i];
        return sum;
    }
}

public class FenwickTree
{
    public int Length { get; }
    private readonly long[] data;
    public FenwickTree(int n)
    {
        this.Length = n;
        this.data = new long[n + 1];
    }
    public void Add(int p, long x)
    {
        Debug.Assert(unchecked((uint)p < data.Length));
        for (p++; p < data.Length; p += p & -p) // p < data.Lengthで比較すると配列アクセスにJIT最適化がかかる
        {
            data[p] += x;
        }
    }
    public long Slice(int l, int length) => Sum(l, l + length);
    public long Sum(Range range) => Sum(range.Start.GetOffset(Length), range.End.GetOffset(Length));
    public long Sum(int l, int r)
    {
        Debug.Assert(0 <= l && l <= r && r < data.Length);
        return Sum(r) - Sum(l);
    }
    private long Sum(int r)
    {
        long s = 0;
        for (; r > 0; r -= r & -r)
        {
            s += data[r];
        }
        return s;
    }
}
```
</details>